### PR TITLE
check for balanced {} and []

### DIFF
--- a/fastjson.lc
+++ b/fastjson.lc
@@ -176,9 +176,20 @@ end jsonFromArray
 #     end if
 #
 ##
+
+constant kJSONStart = "{"
+constant kJSONEnd = "}"
+constant kJSONArrayStart = "["
+constant kJSONArrayEnd = "]"
+constant kJSONDelimiter = ":"
+constant kValidJSONDelimiters = "{}[],:"
+
 function isJson pJson
    local n
+   local tObjectCount, tArrayCount
 
+	 put 0 into tObjectCount
+	 put 0 into tArrayCount
    tokenize pJson
    /*
    repeat for each element tToken in sJson
@@ -191,14 +202,35 @@ function isJson pJson
    put 2 into n
    repeat for each element tToken in sJson
       --repeat with n = 1 to sNumTokens - 1
-      if (sJson[n-1] is not in "{}[],:") and (sJson[n] is not in "{}[],:") then
+      if (sJson[n-1] is not in kValidJSONDelimiters) and (sJson[n] is not in kValidJSONDelimiters) then
          put sJson[n-3] & return & sJson[n-2] &  return & sJson[n-1] &  return & sJson[n] &  return & sJson[n+1] &  return
 
 
          return false
       end if
+      switch tToken
+         case kJSONStart
+            add 1 to tObjectCount
+            break
+         case kJSONEnd
+            subtract 1 from tObjectCount
+            break
+         case kJSONArrayStart
+            add 1 to tArrayCount
+            break
+         case kJSONArrayEnd
+            subtract 1 from tArrayCount
+            break
+      end switch
       add 1 to n
    end repeat
+   if tObjectCount is not 0 then
+      put sNumTokens & cr after msg
+      return "ERR: unbalanced objects:" && tObjectCount
+   end if
+   if tArrayCount is not 0 then
+      return "ERR: unbalanced arrays:" && tArrayCount
+   end if
 
    return true
 end isJson


### PR DESCRIPTION
Here's something I ran into today: the isJson() test passed, but I had an incomplete json object, so the {} tags weren't matching up. This adds balancing checks for {} and [] blocks in addition to the existing token validity checks.
