### PR TITLE
Update fastjson.lc

### DIFF
--- a/fastjson.lc
+++ b/fastjson.lc
@@ -134,7 +134,11 @@ function arrayToJson pArray keepNumeric
       # if keepNumeric is true, then the keys will remain numeric keys
       put "[" into tJSON
       repeat for each element tValue in pArray
-         put jsonValue(tValue) & comma after tJSON
+         if tValue is empty then 
+            put space after tJSON
+         else
+            put jsonValue(tValue) & comma after tJSON
+         end if   
       end repeat
       put "]" into the last char of tJSON
    else


### PR DESCRIPTION
returns an empty array "[]" instead of "[null]" 

for example:

put empty into tArray["someField"][1]
put jsonToArray(tArray) 

produces:

{"someField":[]}

instead of:

{"someField":[null]}
